### PR TITLE
fix: resolve remaining 48 dependabot alerts (lodash, @xmldom, fast-xml-parser, ...)

### DIFF
--- a/examples/million-poc-performance/package.json
+++ b/examples/million-poc-performance/package.json
@@ -41,7 +41,8 @@
     "brace-expansion": "^2.1.3",
     "js-yaml": "^3.15.0",
     "vite": "^4.5.11",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "lodash": "^4.18.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/examples/react-native-expo-router-with-shared-routes/package.json
+++ b/examples/react-native-expo-router-with-shared-routes/package.json
@@ -40,7 +40,10 @@
     "brace-expansion": "^5.0.8",
     "js-yaml": "^3.15.0",
     "uuid": "^11.1.1",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "@xmldom/xmldom": "^0.8.13",
+    "fast-xml-parser": "^5.7.0",
+    "turbo-stream": "^3.0.0"
   },
   "private": true
 }

--- a/examples/react-native-expo-router/package.json
+++ b/examples/react-native-expo-router/package.json
@@ -43,7 +43,10 @@
     "shell-quote": "^1.9.0",
     "tmp": "^0.2.6",
     "uuid": "^11.1.1",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "lodash": "^4.18.0",
+    "@xmldom/xmldom": "^0.8.13",
+    "fast-xml-parser": "^5.7.0"
   },
   "private": true
 }

--- a/examples/react-vite-capacitor-example/package.json
+++ b/examples/react-vite-capacitor-example/package.json
@@ -38,7 +38,8 @@
     "brace-expansion": "^2.1.3",
     "js-yaml": "^3.15.0",
     "vite": "^4.5.11",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "lodash": "^4.18.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/examples/state-management/package.json
+++ b/examples/state-management/package.json
@@ -19,7 +19,9 @@
     "vite": "^4.5.11",
     "js-yaml": "^3.15.0",
     "js-cookie": "^3.0.7",
-    "tmp": "^0.2.6"
+    "tmp": "^0.2.6",
+    "lodash": "^4.18.0",
+    "picomatch": "^2.3.2"
   },
   "devDependencies": {
     "concurrently": "^10.0.4",


### PR DESCRIPTION
New alerts from Dependabot re-scan after PR #254.

**Added overrides for:**
| Package | Alerts | Subprojects |
|---------|--------|-------------|
| lodash | 8 | million-poc, react-vite-capacitor, react-native-expo-router (2), state-management |
| @xmldom/xmldom | 8 | react-native-expo-router (2) |
| fast-xml-parser | 2 | react-native-expo-router (2) |
| picomatch | 2 | state-management |
| turbo-stream | 1 | react-native-expo-router-with-shared-routes |

**Still tracked as issues (breaking):**
- electron v27→v39 (6 alerts) → #221
- react-router v6→v7 (9 alerts) → #147