### PR TITLE
fix(lint): exclude yarn.lock from super-linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v8
         env:
+          FILTER_REGEX_EXCLUDE: .*yarn\.lock.*
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_TYPESCRIPT_STANDARD: false
           VALIDATE_JSCPD: false


### PR DESCRIPTION
Fixes SPELL_CODESPELL errors in dependabot PRs (yarn.lock Nd). Exclude yarn.lock via FILTER_REGEX_EXCLUDE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated linting to exclude lock files from validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->